### PR TITLE
Correct Skills list, revise actor sheet render logic

### DIFF
--- a/scripts/avant.js
+++ b/scripts/avant.js
@@ -135,18 +135,6 @@ class AvantActorData extends foundry.abstract.TypeDataModel {
             
             // Skills System (12 skills from prototype)
             skills: new fields.SchemaField({
-                acrobatics: new fields.NumberField({
-                    required: true,
-                    nullable: false,
-                    integer: true,
-                    initial: 0
-                }),
-                athletics: new fields.NumberField({
-                    required: true,
-                    nullable: false,
-                    integer: true,
-                    initial: 0
-                }),
                 debate: new fields.NumberField({
                     required: true,
                     nullable: false,
@@ -177,31 +165,43 @@ class AvantActorData extends foundry.abstract.TypeDataModel {
                     integer: true,
                     initial: 0
                 }),
-                influence: new fields.NumberField({
+                command: new fields.NumberField({
                     required: true,
                     nullable: false,
                     integer: true,
                     initial: 0
                 }),
-                investigate: new fields.NumberField({
+                charm: new fields.NumberField({
                     required: true,
                     nullable: false,
                     integer: true,
                     initial: 0
                 }),
-                lore: new fields.NumberField({
+                hide: new fields.NumberField({
                     required: true,
                     nullable: false,
                     integer: true,
                     initial: 0
                 }),
-                stealth: new fields.NumberField({
+                inspect: new fields.NumberField({
                     required: true,
                     nullable: false,
                     integer: true,
                     initial: 0
                 }),
-                survival: new fields.NumberField({
+                intuit: new fields.NumberField({
+                    required: true,
+                    nullable: false,
+                    integer: true,
+                    initial: 0
+                }),
+                recall: new fields.NumberField({
+                    required: true,
+                    nullable: false,
+                    integer: true,
+                    initial: 0
+                }),
+                surge: new fields.NumberField({
                     required: true,
                     nullable: false,
                     integer: true,
@@ -357,18 +357,18 @@ class AvantActorData extends foundry.abstract.TypeDataModel {
     // Helper method to get skill ability mapping
     static getSkillAbilities() {
         return {
-            acrobatics: 'grace',
-            athletics: 'might',
             debate: 'intellect',
             discern: 'focus',
             endure: 'focus',
             finesse: 'grace',
             force: 'might',
-            influence: 'focus',
-            investigate: 'intellect',
-            lore: 'intellect',
-            stealth: 'grace',
-            survival: 'might'
+            command: 'might',
+            charm: 'grace',
+            hide: 'grace',
+            inspect: 'intellect',
+            intuit: 'focus',
+            recall: 'intellect',
+            surge: 'might'
         };
     }
 }
@@ -728,6 +728,31 @@ class AvantActorSheet extends foundry.appv1.sheets.ActorSheet {
         const itemTypes = ['action', 'feature', 'talent', 'augment', 'weapon', 'armor', 'gear'];
         itemTypes.forEach(type => {
             if (!context.items[type]) context.items[type] = [];
+        });
+        
+        // Dynamically organize skills by ability for template rendering
+        const skillAbilities = AvantActorData.getSkillAbilities();
+        context.skillsByAbility = {
+            might: [],
+            grace: [],
+            intellect: [],
+            focus: []
+        };
+        
+        // Group skills by their abilities
+        for (const [skillName, abilityName] of Object.entries(skillAbilities)) {
+            if (context.skillsByAbility[abilityName]) {
+                context.skillsByAbility[abilityName].push({
+                    name: skillName,
+                    label: skillName.charAt(0).toUpperCase() + skillName.slice(1),
+                    value: actorData.system.skills[skillName] || 0
+                });
+            }
+        }
+        
+        // Sort skills within each ability group alphabetically
+        Object.keys(context.skillsByAbility).forEach(ability => {
+            context.skillsByAbility[ability].sort((a, b) => a.label.localeCompare(b.label));
         });
         
         return context;
@@ -1478,7 +1503,7 @@ Hooks.once('init', async function() {
         scope: 'world',
         config: false,
         type: String,
-        default: '2.1.0'
+        default: '2.1.9'
     });
 
     // Configure system
@@ -1593,7 +1618,7 @@ Hooks.on('createItem', (item, options, userId) => {
 
 // Export system API
 window['AVANT'] = {
-    version: '2.1.7',
+    version: '2.1.9',
     AvantActorData,
     AvantActionData,
     AvantFeatureData,

--- a/system.json
+++ b/system.json
@@ -51,7 +51,7 @@
     "units": "ft"
   },
   "primaryTokenAttribute": "health",
-  "secondaryTokenAttribute": "power",
+  "secondaryTokenAttribute": "powerPoints",
   "url": "https://github.com/njisaf/AvantVTT",
   "manifest": "https://raw.githubusercontent.com/njisaf/AvantVTT/main/system.json",
   "download": "https://github.com/njisaf/AvantVTT/archive/main.zip"

--- a/templates/actor-sheet.html
+++ b/templates/actor-sheet.html
@@ -436,7 +436,7 @@
                     </div>
                 </div>
 
-                <!-- Skills Tab (reorganized with 2x2 grid layout like Attributes) -->
+                <!-- Skills Tab (Dynamic - generated from AvantActorData.getSkillAbilities()) -->
                 <div class="tab" data-group="primary" data-tab="skills">
                     <div class="skills-section">
                         <h3>Skills</h3>
@@ -447,21 +447,13 @@
                             <div class="skills-ability-section">
                                 <h4 class="skills-ability-header">Might</h4>
                                 <div class="skills-ability-list">
+                                    {{#each skillsByAbility.might as |skill|}}
                                     <div class="skill-tile">
-                                        <label>Athletics</label>
-                                        <input type="text" name="system.skills.athletics" value="{{system.skills.athletics}}" data-dtype="Number"/>
-                                        <button type="button" class="skill-roll" data-skill="athletics" title="Roll Athletics">Roll</button>
+                                        <label>{{skill.label}}</label>
+                                        <input type="text" name="system.skills.{{skill.name}}" value="{{skill.value}}" data-dtype="Number"/>
+                                        <button type="button" class="skill-roll" data-skill="{{skill.name}}" title="Roll {{skill.label}}">Roll</button>
                                     </div>
-                                    <div class="skill-tile">
-                                        <label>Force</label>
-                                        <input type="text" name="system.skills.force" value="{{system.skills.force}}" data-dtype="Number"/>
-                                        <button type="button" class="skill-roll" data-skill="force" title="Roll Force">Roll</button>
-                                    </div>
-                                    <div class="skill-tile">
-                                        <label>Survival</label>
-                                        <input type="text" name="system.skills.survival" value="{{system.skills.survival}}" data-dtype="Number"/>
-                                        <button type="button" class="skill-roll" data-skill="survival" title="Roll Survival">Roll</button>
-                                    </div>
+                                    {{/each}}
                                 </div>
                             </div>
 
@@ -469,21 +461,13 @@
                             <div class="skills-ability-section">
                                 <h4 class="skills-ability-header">Grace</h4>
                                 <div class="skills-ability-list">
+                                    {{#each skillsByAbility.grace as |skill|}}
                                     <div class="skill-tile">
-                                        <label>Acrobatics</label>
-                                        <input type="text" name="system.skills.acrobatics" value="{{system.skills.acrobatics}}" data-dtype="Number"/>
-                                        <button type="button" class="skill-roll" data-skill="acrobatics" title="Roll Acrobatics">Roll</button>
+                                        <label>{{skill.label}}</label>
+                                        <input type="text" name="system.skills.{{skill.name}}" value="{{skill.value}}" data-dtype="Number"/>
+                                        <button type="button" class="skill-roll" data-skill="{{skill.name}}" title="Roll {{skill.label}}">Roll</button>
                                     </div>
-                                    <div class="skill-tile">
-                                        <label>Finesse</label>
-                                        <input type="text" name="system.skills.finesse" value="{{system.skills.finesse}}" data-dtype="Number"/>
-                                        <button type="button" class="skill-roll" data-skill="finesse" title="Roll Finesse">Roll</button>
-                                    </div>
-                                    <div class="skill-tile">
-                                        <label>Stealth</label>
-                                        <input type="text" name="system.skills.stealth" value="{{system.skills.stealth}}" data-dtype="Number"/>
-                                        <button type="button" class="skill-roll" data-skill="stealth" title="Roll Stealth">Roll</button>
-                                    </div>
+                                    {{/each}}
                                 </div>
                             </div>
 
@@ -491,21 +475,13 @@
                             <div class="skills-ability-section">
                                 <h4 class="skills-ability-header">Intellect</h4>
                                 <div class="skills-ability-list">
+                                    {{#each skillsByAbility.intellect as |skill|}}
                                     <div class="skill-tile">
-                                        <label>Debate</label>
-                                        <input type="text" name="system.skills.debate" value="{{system.skills.debate}}" data-dtype="Number"/>
-                                        <button type="button" class="skill-roll" data-skill="debate" title="Roll Debate">Roll</button>
+                                        <label>{{skill.label}}</label>
+                                        <input type="text" name="system.skills.{{skill.name}}" value="{{skill.value}}" data-dtype="Number"/>
+                                        <button type="button" class="skill-roll" data-skill="{{skill.name}}" title="Roll {{skill.label}}">Roll</button>
                                     </div>
-                                    <div class="skill-tile">
-                                        <label>Investigate</label>
-                                        <input type="text" name="system.skills.investigate" value="{{system.skills.investigate}}" data-dtype="Number"/>
-                                        <button type="button" class="skill-roll" data-skill="investigate" title="Roll Investigate">Roll</button>
-                                    </div>
-                                    <div class="skill-tile">
-                                        <label>Lore</label>
-                                        <input type="text" name="system.skills.lore" value="{{system.skills.lore}}" data-dtype="Number"/>
-                                        <button type="button" class="skill-roll" data-skill="lore" title="Roll Lore">Roll</button>
-                                    </div>
+                                    {{/each}}
                                 </div>
                             </div>
 
@@ -513,21 +489,13 @@
                             <div class="skills-ability-section">
                                 <h4 class="skills-ability-header">Focus</h4>
                                 <div class="skills-ability-list">
+                                    {{#each skillsByAbility.focus as |skill|}}
                                     <div class="skill-tile">
-                                        <label>Discern</label>
-                                        <input type="text" name="system.skills.discern" value="{{system.skills.discern}}" data-dtype="Number"/>
-                                        <button type="button" class="skill-roll" data-skill="discern" title="Roll Discern">Roll</button>
+                                        <label>{{skill.label}}</label>
+                                        <input type="text" name="system.skills.{{skill.name}}" value="{{skill.value}}" data-dtype="Number"/>
+                                        <button type="button" class="skill-roll" data-skill="{{skill.name}}" title="Roll {{skill.label}}">Roll</button>
                                     </div>
-                                    <div class="skill-tile">
-                                        <label>Endure</label>
-                                        <input type="text" name="system.skills.endure" value="{{system.skills.endure}}" data-dtype="Number"/>
-                                        <button type="button" class="skill-roll" data-skill="endure" title="Roll Endure">Roll</button>
-                                    </div>
-                                    <div class="skill-tile">
-                                        <label>Influence</label>
-                                        <input type="text" name="system.skills.influence" value="{{system.skills.influence}}" data-dtype="Number"/>
-                                        <button type="button" class="skill-roll" data-skill="influence" title="Roll Influence">Roll</button>
-                                    </div>
+                                    {{/each}}
                                 </div>
                             </div>
                         </div>


### PR DESCRIPTION
Remove incorrect skills and add correct skills; revise script to render skills programmatically in actor-sheet.html

Current skill/category listing:

            debate: 'intellect',
            discern: 'focus',
            endure: 'focus',
            finesse: 'grace',
            force: 'might',
            command: 'might',
            charm: 'grace',
            hide: 'grace',
            inspect: 'intellect',
            intuit: 'focus',
            recall: 'intellect',
            surge: 'might'

<img width="939" alt="image" src="https://github.com/user-attachments/assets/1d4b68fa-1ea6-4377-a922-3c47c5f4edab" />
