### PR TITLE
Feature/gear card attribute

### DIFF
--- a/reports/trait-normalization-20250905.json
+++ b/reports/trait-normalization-20250905.json
@@ -1,0 +1,40 @@
+{
+  "timestamp": "2025-09-05T13:13:25.009Z",
+  "sourceFile": "packs/avant-talents/talents.json",
+  "outputFile": "_export/packs/avant-talents/talents.json",
+  "traitsDirectory": "packs/avant-traits",
+  "totals": {
+    "talentsProcessed": 38,
+    "traitsProcessed": 133,
+    "traitsConverted": 132,
+    "synonymsApplied": 3,
+    "fallbacksUsed": 1,
+    "distinctUnknowns": 1,
+    "duplicatesDetected": 0
+  },
+  "duplicates": [],
+  "fallbacks": [
+    {
+      "talent": "Shove",
+      "originalTrait": "Push"
+    }
+  ],
+  "synonyms": [
+    {
+      "original": "Force",
+      "mapped": "magical",
+      "talent": "Aegis"
+    },
+    {
+      "original": "Area",
+      "mapped": "aoe",
+      "talent": "Dissonate"
+    },
+    {
+      "original": "Area",
+      "mapped": "aoe",
+      "talent": "Radiate"
+    }
+  ],
+  "notes": []
+}

--- a/scripts/data/item-data.js
+++ b/scripts/data/item-data.js
@@ -591,6 +591,11 @@ export class AvantGearData extends foundry.abstract.DataModel {
                 initial: "",
                 blank: true
             }),
+            attribute: new fields.StringField({
+                required: true,
+                initial: "might",
+                choices: ["might", "grace", "intellect", "focus"]
+            }),
             weight: new fields.NumberField({
                 required: true,
                 initial: 1,

--- a/scripts/utils/validation.js
+++ b/scripts/utils/validation.js
@@ -217,6 +217,9 @@ export class ValidationUtils {
                 break;
                 
             case "gear":
+                if (!data.system.attribute) {
+                    data.system.attribute = "might";
+                }
                 if (data.system.weight !== undefined) {
                     data.system.weight = validateNumber(data.system.weight, 1, false);
                 }

--- a/template.json
+++ b/template.json
@@ -266,6 +266,7 @@
       "description": "",
       "weight": 1,
       "cost": 0,
+      "attribute": "might",
       "quantity": 1,
       "rarity": "common",
       "category": "miscellaneous",


### PR DESCRIPTION
Added Attribute field to Gear item-sheet and item-card... only just now noticing the attributes are not init cap'd, so that's next I guess.

<img width="1788" height="872" alt="image" src="https://github.com/user-attachments/assets/e2682fe7-5c3f-45db-bbcf-d6a964c53fa4" />
